### PR TITLE
toggle to use IMAGE_MAGICK

### DIFF
--- a/lib/gmsmith.js
+++ b/lib/gmsmith.js
@@ -7,6 +7,11 @@ var fs = require('fs'),
     exporters = {},
     engine = {};
 
+// Heorku doesn't have Graphics Magick
+if (process.env.IMAGE_MAGICK) {
+  gm = gm.subClass({ imageMagick: true });
+}
+
 function Canvas() {
   var canvas = gm(1, 1, 'transparent');
 


### PR DESCRIPTION
Heroku doesn't support Graphics Magick, so it's nice being able to set an environment variable to toggle it to work [since they do provide image magick]
