### PR TITLE
Extend canvas to given size after adding images

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -3,7 +3,6 @@ var assert = require('assert');
 
 // Define our canvas constructor
 function Canvas(width, height, gmsmith) {
-  // Ignore width/height
   // DEV: Our canvas dimensions are dynamically defined by x/y of each image
   var canvas = gmsmith.gm(1, 1, 'transparent');
 
@@ -12,6 +11,8 @@ function Canvas(width, height, gmsmith) {
 
   // Save the canvas
   this.canvas = canvas;
+  this.width = width;
+  this.height = height;
 }
 Canvas.defaultFormat = 'png';
 Canvas.supportedFormats = ['png', 'jpg', 'jpeg'];
@@ -34,6 +35,9 @@ Canvas.prototype = {
     var format = options.format || Canvas.defaultFormat;
     assert(Canvas.supportedFormats.indexOf(format) !== -1,
       '`gmsmith` doesn\'t support exporting a "' + format + '". Please export either a `png` or `jpeg`');
+
+    // Extent to given size
+    canvas.gravity("NorthWest").extent(this.width, this.height, "!");
 
     // Update the quality of the canvas (if specified)
     var quality = options.quality;


### PR DESCRIPTION
I'm currently using gmsmith for a game sprite packer (https://github.com/gamevy/pixi-packer), e.g. not directly with spritesmith. The feature I'm currently working on forces spritesheets to conform to power-of-two sizes which has certain performance benefits. 

gmsmith is currently ignoring the provided width/height parameter, so I've added an ```.extent``` at the export stage. 

I get this feature isn't directly useful for spritesmith, but I was hoping to avoid having to maintain a fork. It shouldn't have any negative effects (performance or otherwise) as longs as the correct width/height is provided (which spritesmith is doing anyway for the other export plugins).