### PR TITLE
Implement progressive jpeg sprites

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -42,7 +42,7 @@ Canvas.prototype = {
     }
 
     var progressive = options.progressive || false;
-    if (progressive && (format == 'jpeg' || format == 'jpg')) {
+    if (progressive && (format === 'jpeg' || format === 'jpg')) {
       canvas.interlace('Line');
     }
 

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -41,6 +41,11 @@ Canvas.prototype = {
       canvas.quality(quality);
     }
 
+    var progressive = options.progressive || false;
+    if (progressive && (format == 'jpeg' || format == 'jpg')) {
+      canvas.interlace('Line');
+    }
+
     // Export our data via a stream
     // https://github.com/aheckmann/gm/blob/1.21.1/lib/command.js#L116-L144
     return canvas.stream(format);


### PR DESCRIPTION
Just a simple fix to save sprites as  interlaced progressive JPEG format.

>  This is ideal for large images that will be displayed while downloading over a slow connection, allowing a reasonable preview after receiving only a portion of the data. 

Usage:
```js
Spritesmith.run({
    src: arrayOfabsoluteFileNames, 
    engine: require('gmsmith'), 
    exportOpts: {
        progressive: true, 
        format: 'jpg', 
        quality: 60
   }
}, function handleResults(err, result) {
           ...
});
```