### PR TITLE
Update Node.js versions in Travis CI + update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,18 @@
 language: node_js
 sudo: required
 node_js:
-  - "9"
-  - "8"
-  - "6"
-  - "4"
+  - "16"
+  - "14"
+  - "12"
 matrix:
-  allow_failures:
-    - node_js: "9"
   include:
-    - node_js: "8"
+    - node_js: "14"
       env: TEST_GRAPHICSMAGICK=TRUE
-    - node_js: "8"
+    - node_js: "14"
       env: TEST_IMAGEMAGICK=TRUE
-    - node_js: "8"
+    - node_js: "14"
       env: TEST_IMAGEMAGICK=IMPLICIT
-    - node_js: "8"
+    - node_js: "14"
       env: TEST_IMAGEMAGICK=IMPLICIT_WITH_SET
 
 before_install:

--- a/package.json
+++ b/package.json
@@ -31,15 +31,15 @@
     "async": "~1.5.2",
     "gm": "~1.23.1",
     "obj-extend": "~0.1.0",
-    "which": "~1.2.4"
+    "which": "~1.3.1"
   },
   "devDependencies": {
-    "foundry": "~4.3.2",
-    "foundry-release-git": "~2.0.2",
-    "foundry-release-npm": "~2.0.2",
-    "jscs": "~2.11.0",
-    "jshint": "~2.9.0",
-    "mocha": "~2.4.5",
+    "foundry": "~4.6.0",
+    "foundry-release-git": "~2.0.5",
+    "foundry-release-npm": "~2.0.3",
+    "jscs": "~3.0.7",
+    "jshint": "~2.12.0",
+    "mocha": "~8.4.0",
     "spritesmith-engine-test": "~5.0.0",
     "twolfson-style": "~1.6.1"
   },

--- a/test/install.sh
+++ b/test/install.sh
@@ -12,9 +12,9 @@ else
   sudo apt-get remove imagemagick -y
 
   # Download, make, and install graphicsmagick
-  wget http://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/1.3.17/GraphicsMagick-1.3.17.tar.xz/download --output-document GraphicsMagick-1.3.17.tar.xz
-  tar xvf GraphicsMagick-1.3.17.tar.xz
-  cd GraphicsMagick-1.3.17
+  wget http://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/1.3.36/GraphicsMagick-1.3.36.tar.xz/download --output-document GraphicsMagick-1.3.36.tar.xz
+  tar xvf GraphicsMagick-1.3.36.tar.xz
+  cd GraphicsMagick-1.3.36
   ./configure
   make
   sudo make install


### PR DESCRIPTION
Tests still pass locally, so I guess the update of `which` from 1.2.4 to 1.3.1 is not problematic.